### PR TITLE
Fix bug where edit and note don't work properly due to SortedPersons comparator error 

### DIFF
--- a/src/main/java/seedu/address/model/Comparators.java
+++ b/src/main/java/seedu/address/model/Comparators.java
@@ -18,12 +18,8 @@ public class Comparators {
             return -1; // p1 comes before p2
         } else if (!p1.isPinned() && p2.isPinned()) {
             return 1; // p2 comes before p1
-        } else if (p1.isPinned() && p2.isPinned()) {
-            // Both are pinned, sort by timestamp (earlier first)
-            return p1.getPinTimestamp().compareTo(p2.getPinTimestamp());
         } else {
-            // Both unpinned, sort by alphabetical order
-            return p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
+            return 0;
         }
     };
 


### PR DESCRIPTION
- Removed comparing pinTimeStamp between pinned Persons
- This means that sort will sort pinned as well (e.g. sort name will sort the entire addressbook including pinned by name, but pinned is still on the top of the list)
-NOTE: after pinning/unpinning a contact, list will be unsorted again, adding a new contact at this time will make it go on top of the unpinned list. 